### PR TITLE
Add warning about paths with spaces to Create your first snap

### DIFF
--- a/tutorials/packaging/create-your-first-snap/create-your-first-snap.md
+++ b/tutorials/packaging/create-your-first-snap/create-your-first-snap.md
@@ -88,6 +88,9 @@ cd ~/mysnaps/hello
 
 **It is from within this `hello` directory where we will invoke all subsequent commands.**
 
+negative
+: **NOTE:** Due to the limitation of GNU Hello's build system, the path of the directory you put the `hello` directory in *shouldn't contain any spaces*.
+
 Get started by initialising your snap:
 
 ```bash


### PR DESCRIPTION
## Done

Unexpected behavior will occur if one put the snap project under paths with spaces due to GNU Build System's limitation.  This patch adds a warning it so users can avoid such configuration.

## QA

- [x] Check out this feature branch
- [x] Run the site using the command `./run serve`
- [x] View the site locally in your web browser at: [http://0.0.0.0:8016/](http://0.0.0.0:8016/)

## Screenshots
![default](https://user-images.githubusercontent.com/13408130/47479918-2e98e700-d861-11e8-90bb-dcc9e88a54fe.png)
