### PR TITLE
[kiosk] do not pass --devmode flag, snap will inform user about lack of security

### DIFF
--- a/tutorials/iot/ubuntu-kiosk/electron-kiosk.md
+++ b/tutorials/iot/ubuntu-kiosk/electron-kiosk.md
@@ -37,7 +37,7 @@ This tutorial assumes you are familiar with the material in [Make an X11-based K
 [This guide](https://developer.ubuntu.com/core/get-started/installation-medias) shows you how to set up a supported device. If there's no supported image that fits your needs you can [create your own core image](/tutorial/create-your-own-core-image).
     *   **Using a VM**
 You don't have to have a physical "Target Device", you can follow the tutorial with Ubuntu Core in a VM. Install the ubuntu-core-vm snap:
-`snap install --beta ubuntu-core-vm --devmode`
+`snap install --beta ubuntu-core-vm`
 For the first run, create a VM running the latest Core image:
 `sudo ubuntu-core-vm init`
 From then on, you can spin it up with:

--- a/tutorials/iot/ubuntu-kiosk/secure-ubuntu-kiosk.md
+++ b/tutorials/iot/ubuntu-kiosk/secure-ubuntu-kiosk.md
@@ -43,7 +43,7 @@ How to create a graphical kiosk on Ubuntu Core running a single full-screen demo
 [This guide](https://developer.ubuntu.com/core/get-started/installation-medias) shows you how to set up a supported device. If there's no supported image that fits your needs you can [create your own core image](/tutorial/create-your-own-core-image).
     *   **Using a Virtual Machine (VM)**
 You don't need to have a physical "Target Device", you can follow the tutorial with Ubuntu Core in a VM. Install the ubuntu-core-vm snap:
-`snap install --beta ubuntu-core-vm --devmode`
+`snap install --beta ubuntu-core-vm`
 For the first run, create a VM running the latest Core image:
 `sudo ubuntu-core-vm init`
 From then on, you can spin it up with:

--- a/tutorials/iot/ubuntu-kiosk/ubuntu-web-kiosk.md
+++ b/tutorials/iot/ubuntu-kiosk/ubuntu-web-kiosk.md
@@ -43,7 +43,7 @@ How to install a demo web kiosk or web display on Ubuntu Core, and configure it 
 [This guide](https://developer.ubuntu.com/core/get-started/installation-medias) shows you how to set up a supported device. If there's no supported image that fits your needs you can [create your own core image](/tutorial/create-your-own-core-image).
     *   **Using a VM**
 You don't have to have a physical "Target Device", you can follow the tutorial with Ubuntu Core in a VM. Install the ubuntu-core-vm snap:
-`snap install --beta ubuntu-core-vm --devmode`
+`snap install --beta ubuntu-core-vm`
 For the first run, create a VM running the latest Core image:
 `sudo ubuntu-core-vm init`
 From then on, you can spin it up with:

--- a/tutorials/iot/ubuntu-kiosk/wayland-kiosk.md
+++ b/tutorials/iot/ubuntu-kiosk/wayland-kiosk.md
@@ -40,7 +40,7 @@ positive
 [This guide](https://developer.ubuntu.com/core/get-started/installation-medias) shows you how to set up a supported device. If there's no supported image that fits your needs you can [create your own core image](/tutorial/create-your-own-core-image).
     *   **Using a VM**
 You don't have to have a physical "Target Device", you can follow the tutorial with Ubuntu Core in a VM. Install the ubuntu-core-vm snap:
-`snap install --beta ubuntu-core-vm --devmode`
+`snap install --beta ubuntu-core-vm`
 For the first run, create a VM running the latest Core image:
 `sudo ubuntu-core-vm init`
 From then on, you can spin it up with:

--- a/tutorials/iot/ubuntu-kiosk/x11-kiosk.md
+++ b/tutorials/iot/ubuntu-kiosk/x11-kiosk.md
@@ -45,7 +45,7 @@ negative
 [This guide](https://developer.ubuntu.com/core/get-started/installation-medias) shows you how to set up a supported device. If there's no supported image that fits your needs you can [create your own core image](/tutorial/create-your-own-core-image).
     *   **Using a VM**
 You don't have to have a physical "Target Device", you can follow the tutorial with Ubuntu Core in a VM. Install the ubuntu-core-vm snap:
-`sudo snap install --beta ubuntu-core-vm --devmode`
+`sudo snap install --beta ubuntu-core-vm`
 For the first run, create a VM running the latest Core image:
 `sudo ubuntu-core-vm init`
 From then on, you can spin it up with:


### PR DESCRIPTION
Including "--devmode" in the ubuntu-core-vm install command means user is not informed about the install. Remove it, so that snap will print informative message about the security impact, so user can make informed decision