### PR TITLE
[iot] update kiosk guide to reflect snapd/snapcraft changes

### DIFF
--- a/tutorials/iot/ubuntu-kiosk/electron-kiosk.md
+++ b/tutorials/iot/ubuntu-kiosk/electron-kiosk.md
@@ -163,7 +163,7 @@ Some points about this YAML
 *   [snapcraft-desktop-helpers](https://github.com/ubuntu/snapcraft-desktop-helpers/blob/master/snapcraft.yaml#L1) is used to ease environment setup for electron. We need to copy/paste the relevant YAML right now. 
 *   npm is the packaging tool being used
 *   It uses "[electron-packager](https://www.npmjs.com/package/electron-packager)" to build the electron app.
-*   the"[override-build](https://docs.snapcraft.io/build-snaps/scriptlets#overriding-the-build-step)" scriptlet is used to run commands to install electron-packager, build the package and install the final binary into a suitable location in the snap.
+*   the"[override-build](https://docs.snapcraft.io/scriptlets#heading--overriding-the-build-step)" scriptlet is used to run commands to install electron-packager, build the package and install the final binary into a suitable location in the snap.
 *   the stage-packages are those we find necessary for the final binary to function. You may need to add more depending on the complexity of your application.
 *   it supports i386, amd64, armhf and arm64.
 

--- a/tutorials/iot/ubuntu-kiosk/electron-kiosk.md
+++ b/tutorials/iot/ubuntu-kiosk/electron-kiosk.md
@@ -33,7 +33,7 @@ This tutorial assumes you are familiar with the material in [Make an X11-based K
 
 *   An Ubuntu desktop running any current release of Ubuntu or an Ubuntu Virtual Machine on another OS.
 *   A 'Target Device' from one of the following:
-    *   **A device running [Ubuntu Core](https://www.ubuntu.com/core).**<br />
+    *   **A device running [Ubuntu Core 18](https://www.ubuntu.com/core).**<br />
 [This guide](https://developer.ubuntu.com/core/get-started/installation-medias) shows you how to set up a supported device. If there's no supported image that fits your needs you can [create your own core image](/tutorial/create-your-own-core-image).
     *   **Using a VM**
 You don't have to have a physical "Target Device", you can follow the tutorial with Ubuntu Core in a VM. Install the ubuntu-core-vm snap:
@@ -44,11 +44,7 @@ From then on, you can spin it up with:
 `sudo ubuntu-core-vm`
 You should see a new window with Ubuntu Core running inside. Setting up Ubuntu Core on this VM is the same as for any other device or VM. See, for example, [https://developer.ubuntu.com/core/get-started/kvm](https://developer.ubuntu.com/core/get-started/kvm).
     *   **Using Ubuntu Classic**
-You don't _have_ to use Ubuntu Core, you can use also a "Target Device" with Ubuntu Classic. You just need to install an SSH server on the device.
-`sudo apt install ssh`
-For IoT use you will want to make other changes (e.g. uninstalling the desktop), but that is outside the scope of the current tutorial.
-Note: On Classic snapd doesn't currently provide confinement for snapped wayland or x11 servers, so you'll need to use devmode.
-
+You don't _have_ to use Ubuntu Core, you can use also a "Target Device" with Ubuntu Classic. Read [this guide](https://discourse.ubuntu.com/t/howto-run-your-kiosk-snap-on-your-desktop/11180) to understand how to run kiosk snaps on your desktop, as the particular details won't be repeated here.
 
 ## Architecture of Electron snaps with Wayland
 

--- a/tutorials/iot/ubuntu-kiosk/electron-kiosk.md
+++ b/tutorials/iot/ubuntu-kiosk/electron-kiosk.md
@@ -77,10 +77,11 @@ This guide will start with a working hello-world snap for Electron, that functio
 
 ```yaml
 name: electron-hello-world-kiosk
-version: 0.1
+version: '0.1'
 summary: Hello World Electron app
 description: |
   Simple Hello World Electron app as an example
+base: core18
 confinement: strict
 grade: devel
 
@@ -105,7 +106,7 @@ parts:
   electron-helloworld:
     plugin: nodejs
     source: https://github.com/electron/electron-quick-start.git
-    after: [desktop-gtk2]
+    after: [desktop-gtk3]
     override-build: |
         case $SNAPCRAFT_ARCH_TRIPLET in
           "i386-linux-gnu") ARCH="ia32";;
@@ -121,8 +122,41 @@ parts:
     - libasound2
     - libgconf-2-4
     - libnss3
+    - libx11-xcb1
     - libxss1
     - libxtst6
+
+    build-packages:
+    - nodejs
+    - npm
+
+  # Adapted from snapcraft-desktop-helpers https://github.com/ubuntu/snapcraft-desktop-helpers/blob/master/snapcraft.yaml#L183
+  desktop-gtk3:
+    source: https://github.com/ubuntu/snapcraft-desktop-helpers.git
+    source-subdir: gtk
+    plugin: make
+    make-parameters: ["FLAVOR=gtk3"]
+    build-packages:
+      - build-essential
+      - libgtk-3-dev
+    stage-packages:
+      - libxkbcommon0  # XKB_CONFIG_ROOT
+      - ttf-ubuntu-font-family
+      - dmz-cursor-theme
+      - light-themes
+      - adwaita-icon-theme
+      - gnome-themes-standard
+      - shared-mime-info
+      - libgtk-3-0
+      - libgdk-pixbuf2.0-0
+      - libglib2.0-bin
+      - libgtk-3-bin
+      - unity-gtk3-module
+      - libappindicator3-1
+      - locales-all
+      - xdg-user-dirs
+      - ibus-gtk3
+      - libibus-1.0-5    
 ```
 
 
@@ -130,7 +164,7 @@ Some points about this YAML
 
 
 
-*   [snapcraft-desktop-helpers](https://github.com/ubuntu/snapcraft-desktop-helpers/blob/master/snapcraft.yaml#L1) is used to ease environment setup for electron
+*   [snapcraft-desktop-helpers](https://github.com/ubuntu/snapcraft-desktop-helpers/blob/master/snapcraft.yaml#L1) is used to ease environment setup for electron. We need to copy/paste the relevant YAML right now. 
 *   npm is the packaging tool being used
 *   It uses "[electron-packager](https://www.npmjs.com/package/electron-packager)" to build the electron app.
 *   the"[override-build](https://docs.snapcraft.io/build-snaps/scriptlets#overriding-the-build-step)" scriptlet is used to run commands to install electron-packager, build the package and install the final binary into a suitable location in the snap.
@@ -144,7 +178,7 @@ Build the snap with:
 
 
 ```bash
-snapcraft cleanbuild
+snapcraft
 ```
 
 
@@ -174,6 +208,7 @@ Once the snap is running on your Ubuntu desktop, we need to perform a few altera
 1.  and make it a daemon by adding `daemon: simple `and` restart-condition: always`
 1.  set the `XWAYLAND_FULLSCREEN_WINDOW_HINT` environment variable to `window_role="browser-window"`
 1.  have `x11` be both a socket and a plug - involves creating a x11-plug to avoid duplicate names.
+1.  append the YAML for the `xwayland-kiosk-helper` part
 
 Finally we want this snap to start on boot and be restarted if it fails, so make it a daemon.
 
@@ -182,10 +217,11 @@ The final YAML file will look like this:
 
 ```yaml
 name: electron-hello-world-kiosk
-version: 0.1
+version: '0.1'
 summary: Hello World Electron app for a Kiosk
 description: |
   Simple Hello World Electron app as an example of a HTML5 Kiosk
+base: core18
 confinement: strict
 grade: devel
 
@@ -217,7 +253,7 @@ parts:
   electron-helloworld:
     plugin: nodejs
     source: https://github.com/electron/electron-quick-start.git
-    after: [desktop-gtk2, xwayland-kiosk-helper]
+    after: [desktop-gtk3, xwayland-kiosk-helper]
     override-build: |
         case $SNAPCRAFT_ARCH_TRIPLET in
           "i386-linux-gnu") ARCH="ia32";;
@@ -233,8 +269,46 @@ parts:
     - libasound2
     - libgconf-2-4
     - libnss3
+    - libx11-xcb1
     - libxss1
     - libxtst6
+    build-packages:
+    - nodejs
+    - npm
+
+  # Adapted from snapcraft-desktop-helpers https://github.com/ubuntu/snapcraft-desktop-helpers/blob/master/snapcraft.yaml#L183
+  desktop-gtk3:
+    source: https://github.com/ubuntu/snapcraft-desktop-helpers.git
+    source-subdir: gtk
+    plugin: make
+    make-parameters: ["FLAVOR=gtk3"]
+    build-packages:
+      - build-essential
+      - libgtk-3-dev
+    stage-packages:
+      - libxkbcommon0  # XKB_CONFIG_ROOT
+      - ttf-ubuntu-font-family
+      - dmz-cursor-theme
+      - light-themes
+      - adwaita-icon-theme
+      - gnome-themes-standard
+      - shared-mime-info
+      - libgtk-3-0
+      - libgdk-pixbuf2.0-0
+      - libglib2.0-bin
+      - libgtk-3-bin
+      - unity-gtk3-module
+      - libappindicator3-1
+      - locales-all
+      - xdg-user-dirs
+      - ibus-gtk3
+      - libibus-1.0-5
+
+  xwayland-kiosk-helper:
+    plugin: cmake
+    source: https://github.com/MirServer/xwayland-kiosk-helper.git
+    build-packages: [ build-essential ]
+    stage-packages: [ xwayland, i3, libegl1-mesa, libgl1-mesa-glx ]
 ```
 
 
@@ -242,7 +316,7 @@ Build as usual with
 
 
 ```bash
-snapcraft cleanbuild
+snapcraft
 ```
 
 

--- a/tutorials/iot/ubuntu-kiosk/electron-kiosk.md
+++ b/tutorials/iot/ubuntu-kiosk/electron-kiosk.md
@@ -37,7 +37,7 @@ This tutorial assumes you are familiar with the material in [Make an X11-based K
 [This guide](https://developer.ubuntu.com/core/get-started/installation-medias) shows you how to set up a supported device. If there's no supported image that fits your needs you can [create your own core image](/tutorial/create-your-own-core-image).
     *   **Using a VM**
 You don't have to have a physical "Target Device", you can follow the tutorial with Ubuntu Core in a VM. Install the ubuntu-core-vm snap:
-`snap install --beta ubuntu-core-vm --devmode`
+`sudo snap install --beta ubuntu-core-vm --devmode`
 For the first run, create a VM running the latest Core image:
 `sudo ubuntu-core-vm init`
 From then on, you can spin it up with:

--- a/tutorials/iot/ubuntu-kiosk/secure-ubuntu-kiosk.md
+++ b/tutorials/iot/ubuntu-kiosk/secure-ubuntu-kiosk.md
@@ -43,7 +43,7 @@ How to create a graphical kiosk on Ubuntu Core running a single full-screen demo
 [This guide](https://developer.ubuntu.com/core/get-started/installation-medias) shows you how to set up a supported device. If there's no supported image that fits your needs you can [create your own core image](/tutorial/create-your-own-core-image).
     *   **Using a Virtual Machine (VM)**
 You don't need to have a physical "Target Device", you can follow the tutorial with Ubuntu Core in a VM. Install the ubuntu-core-vm snap:
-`snap install --beta ubuntu-core-vm --devmode`
+`sudo snap install --beta ubuntu-core-vm --devmode`
 For the first run, create a VM running the latest Core image:
 `sudo ubuntu-core-vm init`
 From then on, you can spin it up with:

--- a/tutorials/iot/ubuntu-kiosk/secure-ubuntu-kiosk.md
+++ b/tutorials/iot/ubuntu-kiosk/secure-ubuntu-kiosk.md
@@ -39,7 +39,7 @@ How to create a graphical kiosk on Ubuntu Core running a single full-screen demo
 
 *   An Ubuntu desktop running any current release of Ubuntu or an Ubuntu Virtual Machine on another OS.
 *   A 'Target Device' from one of the following:
-    *   **A device running [Ubuntu Core](https://www.ubuntu.com/core).**<br />
+    *   **A device running [Ubuntu Core 18](https://www.ubuntu.com/core).**<br />
 [This guide](https://developer.ubuntu.com/core/get-started/installation-medias) shows you how to set up a supported device. If there's no supported image that fits your needs you can [create your own core image](/tutorial/create-your-own-core-image).
     *   **Using a Virtual Machine (VM)**
 You don't need to have a physical "Target Device", you can follow the tutorial with Ubuntu Core in a VM. Install the ubuntu-core-vm snap:
@@ -49,11 +49,8 @@ For the first run, create a VM running the latest Core image:
 From then on, you can spin it up with:
 `sudo ubuntu-core-vm`
 You should see a new window with Ubuntu Core running inside. Setting up Ubuntu Core on this VM is the same as for any other device or VM. See, for example, [https://developer.ubuntu.com/core/get-started/kvm](https://developer.ubuntu.com/core/get-started/kvm).
-    *   **Using Ubuntu Classic (Desktop/Server)**
-You don't _have_ to use Ubuntu Core, you can use also a "Target Device" with Ubuntu Classic. You just need to install an SSH server on the device.
-`sudo apt install ssh`
-For IoT use you may want to make other changes (e.g. uninstalling the desktop), but that is outside the scope of the current tutorial.
-Note: On Classic snapd doesn't currently provide confinement for snapped wayland or x11 servers, so you'll need to use devmode.
+    *   **Using Ubuntu Classic**
+You don't _have_ to use Ubuntu Core, you can use also a "Target Device" with Ubuntu Classic. Read [this guide](https://discourse.ubuntu.com/t/howto-run-your-kiosk-snap-on-your-desktop/11180) to understand how to run kiosk snaps on your desktop, as the particular details won't be repeated here.
 
 
 ## Basic Infrastructure

--- a/tutorials/iot/ubuntu-kiosk/ubuntu-web-kiosk.md
+++ b/tutorials/iot/ubuntu-kiosk/ubuntu-web-kiosk.md
@@ -43,7 +43,7 @@ How to install a demo web kiosk or web display on Ubuntu Core, and configure it 
 [This guide](https://developer.ubuntu.com/core/get-started/installation-medias) shows you how to set up a supported device. If there's no supported image that fits your needs you can [create your own core image](/tutorial/create-your-own-core-image).
     *   **Using a VM**
 You don't have to have a physical "Target Device", you can follow the tutorial with Ubuntu Core in a VM. Install the ubuntu-core-vm snap:
-`snap install --beta ubuntu-core-vm --devmode`
+`sudo snap install --beta ubuntu-core-vm --devmode`
 For the first run, create a VM running the latest Core image:
 `sudo ubuntu-core-vm init`
 From then on, you can spin it up with:

--- a/tutorials/iot/ubuntu-kiosk/wayland-kiosk.md
+++ b/tutorials/iot/ubuntu-kiosk/wayland-kiosk.md
@@ -747,34 +747,48 @@ snapcraft
 ```
 
 
-However you need to build the snap for a different CPU architecture, it is not quite as simple…
+However you need to build the snap for a different CPU architecture, it is not quite as simple. However we provide a build service to help with this.
 
 
-### Building snaps using Launchpad
+### Building snaps using the Snapcraft build service
 
-One day, perhaps, snapcraft will fully support cross building with the `--target-arch` option. But getting that to work is beyond the scope of this tutorial. Instead we'll make use of Launchpad's builders to build the snap for all architectures (including the one your device provides).
+One day, perhaps, snapcraft will fully support cross building with the `--target-arch` option. But getting that to work is beyond the scope of this tutorial. Instead we'll make use of [Snapcraft builders](https://snapcraft.io/build) to build the snap for all architectures (including the one your device provides).
 
-Create a github repository for your snap and push your changes to the snap project there:
+[Create a GitHub repository](https://github.com/new) for your snap and push your changes to the snap project there:
 
 
 ```bash
 git init
 git commit -a
 git remote remove origin
-git remote add origin https://github.com/<project>/<repo>.git
+git remote add origin https://github.com/<username>/<repo>.git
 git push -u origin master
 ```
 
 
-Now [set up your build on Launchpad](https://docs.snapcraft.io/build-snaps/ci-integration). Note that you will need to use the same snap name in the store as in `name:`, so choose something unique to make your life easier.
+Now [visit Snapcraft Build](https://snapcraft.io/build) and follow the "Set up in Minutes" link. You can configure Snapcraft Build to watch your GitHub repository, and it will auto-build Snaps supporting multiple architectures: amd64, i386, armhf and amd64, ppc64el and s390x. This is a free shared build service so there can be delays before your build is started.
 
-Don't bother with publishing to the store (yet), you can download the snap and deploy it as follows:
+Visiting the link
 
-On your desktop go to the snap webpage ([https://code.launchpad.net/~/+snaps](https://code.launchpad.net/~/+snaps)), find the build for your device architecture and download it. For example:
+```
+https://build.snapcraft.io/user/<username>/<repo>
+```
+
+will show you your build status, allow you to find where the built Snaps are, and trigger a new build.
+
+To download the built Snap, you need to click on the build number of the architecture you need, and the first line of the build log will be a URL pointing at Launchpad (of this form):
+
+```
+https://launchpad.net/~build.snapcraft.io/+snap/91eff219d76d5721eb24ffb6a83032b6/+build/593821
+```
+
+Visiting this URL, you can find the built Snap under the "Built files" section.
+
+To test your snap on your target device, find the build for your device architecture and download it. Or you can grab its URL and download it directly to your device:
 
 
 ```bash
-wget https://launchpad.net/~mir-team/+snap/glmark2-example/+build/322360/+files/glmark2-example_0.1_amd64.snap
+wget https://launchpad.net/~build.snapcraft.io/+snap/91eff219d76d5721eb24ffb6a83032b6/+build/593821/+files/glmark2-wayland_0.1_armhf.snap
 ```
 
 

--- a/tutorials/iot/ubuntu-kiosk/wayland-kiosk.md
+++ b/tutorials/iot/ubuntu-kiosk/wayland-kiosk.md
@@ -36,21 +36,18 @@ positive
 
 *   An Ubuntu desktop running any current release of Ubuntu or an Ubuntu Virtual Machine on another OS.
 *   A 'Target Device' from one of the following:
-    *   **A device running [Ubuntu Core](https://www.ubuntu.com/core).**<br />
+    *   **A device running [Ubuntu Core 18](https://www.ubuntu.com/core).**<br />
 [This guide](https://developer.ubuntu.com/core/get-started/installation-medias) shows you how to set up a supported device. If there's no supported image that fits your needs you can [create your own core image](/tutorial/create-your-own-core-image).
     *   **Using a VM**
 You don't have to have a physical "Target Device", you can follow the tutorial with Ubuntu Core in a VM. Install the ubuntu-core-vm snap:
 `snap install --beta ubuntu-core-vm --devmode`
-For the first run, create a VM running the latest Core image:
+For the first run, create a VM running the latest Core 18 image:
 `sudo ubuntu-core-vm init`
 From then on, you can spin it up with:
 `sudo ubuntu-core-vm`
 You should see a new window with Ubuntu Core running inside. Setting up Ubuntu Core on this VM is the same as for any other device or VM. See, for example, [https://developer.ubuntu.com/core/get-started/kvm](https://developer.ubuntu.com/core/get-started/kvm).
     *   **Using Ubuntu Classic**
-You don't _have_ to use Ubuntu Core, you can use also a "Target Device" with Ubuntu Classic. You just need to install an SSH server on the device.
-`sudo apt install ssh`
-For IoT use you will want to make other changes (e.g. uninstalling the desktop), but that is outside the scope of the current tutorial.
-
+You don't _have_ to use Ubuntu Core, you can use also a "Target Device" with Ubuntu Classic. Read [this guide](https://discourse.ubuntu.com/t/howto-run-your-kiosk-snap-on-your-desktop/11180) to understand how to run kiosk snaps on your desktop, as the particular details won't be repeated here.
 
 ## Using Wayland
 
@@ -484,21 +481,6 @@ Error: main: Could not initialize canvas
 
 Courage! This is progress, we’re almost done in fact. There’s just one more thing to fix…
 
-positive
-: Note for when using “core” (aka “core16”) as the base
-
-Up to this stage, there is no distinction between core16 and core18. But if using core16, the above error messages will be slightly different:
-
-
-```
-libEGL warning: DRI2: failed to open swrast (search paths /usr/lib/x86_64-linux-gnu/dri:${ORIGIN}/dri:/usr/lib/dri)
-Error: eglInitialize() failed with error: 0x3001
-Error: main: Could not initialize canvas
-```
-
-
-Not to worry, the next section will provide the solution.
-
 
 
 ## Common Problem 3: GL drivers are not where they usually are
@@ -509,20 +491,11 @@ This is another typical problem for snapping graphics applications: the GL drive
 
 Is this "files are not where they're expected to be" yet again? Yes, but here we are lucky as there’s environment variables we can use to specify the correct location for the GL driver files (you could use layouts too, but this is more efficient).
 
-If using “core18” as the base, simply use:
+Simply use:
 
 
 ```bash
 export __EGL_VENDOR_LIBRARY_DIRS="$SNAP/etc/glvnd/egl_vendor.d:$SNAP/usr/share/glvnd/egl_vendor.d"
-```
-
-
-Otherwise, using “core” (aka “core16”) as the base, you need
-
-
-```bash
-export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$SNAP/usr/lib/x86_64-linux-gnu/mesa-egl:$SNAP/usr/lib/x86_64-linux-gnu/mesa"
-export LIBGL_DRIVERS_PATH="$SNAP/usr/lib/x86_64-linux-gnu/dri"
 ```
 
 
@@ -587,7 +560,7 @@ Another option (which we will use here) is to adjust the `command:` like this:
 ```
 
 
-We can ask snapcraft to set the environment variables to fix graphics by adding an `environment` entry for the command. For core18:
+We can ask snapcraft to set the environment variables to fix graphics by adding an `environment` entry for the command:
 
 
 ```
@@ -596,21 +569,6 @@ We can ask snapcraft to set the environment variables to fix graphics by adding 
       __EGL_VENDOR_LIBRARY_DIRS: "$SNAP/etc/glvnd/egl_vendor.d:$SNAP/usr/share/glvnd/egl_vendor.d"
 …
 ```
-
-
-or for core16:
-
-
-```
-…
-    environment:
-      LD_LIBRARY_PATH: "$LD_LIBRARY_PATH:$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/mesa-egl:$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/mesa"
-      LIBGL_DRIVERS_PATH: "$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/dri"
-…
-```
-
-
-(Note the use of `$SNAPCRAFT_ARCH_TRIPLET` that inserts the correct triplet for the architecture you’re building for)
 
 
 We can also enable strict confinement and see if everything works. Due to the care we took above, it does. Your own application may require more tweaking to function fully confined however.
@@ -688,7 +646,7 @@ duration: 3:00
 
 The goal here is to have our graphical snap running full-screen on your device.
 
-Before we proceed, you need to have Ubuntu Core [already running on your device](#0).
+Before we proceed, you need to have Ubuntu Core 18 [already running on your device](#0).
 
 
 ### Device Setup

--- a/tutorials/iot/ubuntu-kiosk/wayland-kiosk.md
+++ b/tutorials/iot/ubuntu-kiosk/wayland-kiosk.md
@@ -104,7 +104,7 @@ snap install snapcraft --classic
 ```
 
 
-and install [Multipass](https://github.com/CanonicalLtd/multipass):
+and install [Multipass](https://snapcraft.io/multipass):
 
 
 ```bash

--- a/tutorials/iot/ubuntu-kiosk/wayland-kiosk.md
+++ b/tutorials/iot/ubuntu-kiosk/wayland-kiosk.md
@@ -40,7 +40,7 @@ positive
 [This guide](https://developer.ubuntu.com/core/get-started/installation-medias) shows you how to set up a supported device. If there's no supported image that fits your needs you can [create your own core image](/tutorial/create-your-own-core-image).
     *   **Using a VM**
 You don't have to have a physical "Target Device", you can follow the tutorial with Ubuntu Core in a VM. Install the ubuntu-core-vm snap:
-`snap install --beta ubuntu-core-vm --devmode`
+`sudo snap install --beta ubuntu-core-vm --devmode`
 For the first run, create a VM running the latest Core 18 image:
 `sudo ubuntu-core-vm init`
 From then on, you can spin it up with:
@@ -97,7 +97,7 @@ To build snaps, you need to install snapcraft:
 
 
 ```bash
-snap install snapcraft --classic
+sudo snap install snapcraft --classic
 ```
 
 
@@ -105,7 +105,7 @@ and install [Multipass](https://snapcraft.io/multipass):
 
 
 ```bash
-snap install multipass --classic --beta
+sudo snap install multipass --classic --beta
 ```
 
 

--- a/tutorials/iot/ubuntu-kiosk/wayland-kiosk.md
+++ b/tutorials/iot/ubuntu-kiosk/wayland-kiosk.md
@@ -495,16 +495,15 @@ Simply use:
 
 
 ```bash
-export __EGL_VENDOR_LIBRARY_DIRS="$SNAP/etc/glvnd/egl_vendor.d:$SNAP/usr/share/glvnd/egl_vendor.d"
+root@in-snap:~# export __EGL_VENDOR_LIBRARY_DIRS="$SNAP/etc/glvnd/egl_vendor.d:$SNAP/usr/share/glvnd/egl_vendor.d"
 ```
 
 
 Now try once more:
 
 
-```
-lang:bash
-$SNAP/command-glmark2-example.wrapper
+```bash
+root@in-snap:~# $SNAP/command-glmark2-example.wrapper
 ```
 
 
@@ -517,7 +516,7 @@ positive
 This is easy to work around: use a different Wayland socket name to avoid confusion:
 
 
-```
+```bash
 miral-kiosk --wayland-socket-name mir-kiosk&
 export WAYLAND_DISPLAY=mir-kiosk
 snap run glmark2-example

--- a/tutorials/iot/ubuntu-kiosk/x11-kiosk.md
+++ b/tutorials/iot/ubuntu-kiosk/x11-kiosk.md
@@ -41,7 +41,7 @@ negative
 
 *   An Ubuntu desktop running any current release of Ubuntu or an Ubuntu Virtual Machine on another OS.
 *   A 'Target Device' from one of the following:
-    *   **A device running [Ubuntu Core](https://www.ubuntu.com/core).**<br />
+    *   **A device running [Ubuntu Core 18](https://www.ubuntu.com/core).**<br />
 [This guide](https://developer.ubuntu.com/core/get-started/installation-medias) shows you how to set up a supported device. If there's no supported image that fits your needs you can [create your own core image](/tutorial/create-your-own-core-image).
     *   **Using a VM**
 You don't have to have a physical "Target Device", you can follow the tutorial with Ubuntu Core in a VM. Install the ubuntu-core-vm snap:
@@ -52,11 +52,7 @@ From then on, you can spin it up with:
 `sudo ubuntu-core-vm`
 You should see a new window with Ubuntu Core running inside. Setting up Ubuntu Core on this VM is the same as for any other device or VM. See, for example, [https://developer.ubuntu.com/core/get-started/kvm](https://developer.ubuntu.com/core/get-started/kvm).
     *   **Using Ubuntu Classic**
-You don't _have_ to use Ubuntu Core, you can use also a "Target Device" with Ubuntu Classic. You just need to install an SSH server on the device.
-`sudo apt install ssh`
-For IoT use you will want to make other changes (e.g. uninstalling the desktop), but that is outside the scope of the current tutorial.
-Note: On Classic snapd doesn't currently provide confinement for snapped wayland or x11 servers, so you'll need to use devmode.
-
+You don't _have_ to use Ubuntu Core, you can use also a "Target Device" with Ubuntu Classic. Read [this guide](https://discourse.ubuntu.com/t/howto-run-your-kiosk-snap-on-your-desktop/11180) to understand how to run kiosk snaps on your desktop, as the particular details won't be repeated here.
 
 ## X11 on top of Wayland
 

--- a/tutorials/iot/ubuntu-kiosk/x11-kiosk.md
+++ b/tutorials/iot/ubuntu-kiosk/x11-kiosk.md
@@ -213,7 +213,7 @@ This is the basic setup that we'll have in our snap. It seems like a lot of work
 
 duration: 5:00
 
-For our first pass we will snap glxgears and run it in devmode (i.e. unconfined) on our Ubuntu desktop. We will include an [xwayland-kiosk-helper](https://github.com/MirServer/xwayland-kiosk-helper/) part that make life easier, it contains a script that runs the above commands for us.
+For our first pass we will snap glxgears and run it in devmode (i.e. unconfined) on our Ubuntu desktop. We will include an [xwayland-kiosk-helper](https://github.com/MirServer/xwayland-kiosk-helper/) part that makes life easier, it contains a script that runs the above commands for us.
 
 This guide assumes you are familiar with creating snaps. If not, please read [here](https://docs.snapcraft.io/build-snaps/) first. 
 

--- a/tutorials/iot/ubuntu-kiosk/x11-kiosk.md
+++ b/tutorials/iot/ubuntu-kiosk/x11-kiosk.md
@@ -140,7 +140,7 @@ glxgears
 and in a separate terminal, run
 
 
-```
+```bash
 xprop
 ```
 
@@ -226,10 +226,11 @@ Inside the glxgears directory edit the "snap/snapcraft.yaml" file, and let's try
 
 ```yaml
 name: glxgears-example
-version: 0.1
+version: '0.1'
 summary: glxgears example kiosk
 description: |
   glxgears example X11 kiosk, using Xwayland and Wayland
+base: core18
 confinement: strict
 grade: devel
 
@@ -310,10 +311,11 @@ Here is a suitable first candidate snapcraft.yaml file:
 
 ```yaml
 name: glxgears-example
-version: 0.1
+version: '0.1'
 summary: glxgears example kiosk
 description: |
   glxgears example X11 kiosk, using Xwayland and Wayland
+base: core18
 confinement: devmode
 grade: devel
 
@@ -425,10 +427,11 @@ To update the snap to use the X11 interface we need to update the "snap/snapcraf
 
 ```yaml
 name: glxgears-example
-version: 0.1
+version: '0.1'
 summary: glxgears example kiosk
 description: |
   glxgears example X11 kiosk, using Xwayland and Wayland
+base: core18
 confinement: strict
 grade: devel
 

--- a/tutorials/iot/ubuntu-kiosk/x11-kiosk.md
+++ b/tutorials/iot/ubuntu-kiosk/x11-kiosk.md
@@ -352,36 +352,47 @@ snapcraft
 ```
 
 
-
-## Building for different architectures
+## Building snaps for different architectures
 
 duration: 10:00
 
-One day, perhaps, snapcraft will fully support cross building with the --target-arch option. But getting that to work is beyond the scope of this tutorial. Instead we'll make use of Launchpad's builders to build the snap for all architectures (including the one your device provides).
+One day, perhaps, snapcraft will fully support cross building with the `--target-arch` option. But getting that to work is beyond the scope of this tutorial. Instead we'll make use of [Snapcraft builders](https://snapcraft.io/build) to build the snap for all architecture$
 
-Create a github repository for your snap and push your changes to the snap project there:
+[Create a GitHub repository](https://github.com/new) for your snap and push your changes to the snap project there:
 
 
 ```bash
 git init
 git commit -a
 git remote remove origin
-git remote add origin https://github.com/<project>/<repo>.git
+git remote add origin https://github.com/<username>/<repo>.git
 git push -u origin master
 ```
 
 
-Now [set up your build on Launchpad](https://docs.snapcraft.io/build-snaps/ci-integration). Note that you will need to use the same snap name in the store as in `name:`, so choose something unique to make your life easier.
+Now [visit Snapcraft Build](https://snapcraft.io/build) and follow the "Set up in Minutes" link. You can configure Snapcraft Build to watch your GitHub repository, and it will auto-build Snaps supporting multiple architectures: amd64, i386, armhf and amd64, ppc64el and s$
 
-Don't bother with publishing to the store (yet) you can download the snap and deploy it as follows:
+Visiting the link
 
-On your desktop go to the snaps webpage (e.g. [https://code.launchpad.net/~/+snaps](https://code.launchpad.net/%7E/+snaps)), find the build for your device architecture and download it and copy to your device. For example:
+```
+https://build.snapcraft.io/user/<username>/<repo>
+```
+
+will show you your build status, allow you to find where the built Snaps are, and trigger a new build.
+
+To download the built Snap, you need to click on the build number of the architecture you need, and the first line of the build log will be a URL pointing at Launchpad (of this form):
+
+```
+https://launchpad.net/~build.snapcraft.io/+snap/91eff219d76d5721eb24ffb6a83032b6/+build/593821
+```
+
+Visiting this URL, you can find the built Snap under the "Built files" section.
+
+To test your snap on your target device, find the build for your device architecture and download it. Or you can grab its URL and download it directly to your device:
 
 
 ```bash
-wget https://code.launchpad.net/~mir-team/+snap/glxgears-example/+build/337696/+files/glxgears-example_0.1_amd64.snap
-```
-
+wget https://launchpad.net/~build.snapcraft.io/+snap/91eff219d76d5721eb24ffb6a83032b6/+build/593821/+files/glxgears-example_0.1_armhf.snap
 
 
 ## Deploy the snap on the device

--- a/tutorials/iot/ubuntu-kiosk/x11-kiosk.md
+++ b/tutorials/iot/ubuntu-kiosk/x11-kiosk.md
@@ -304,14 +304,6 @@ Now you should have a black screen with a white mouse cursor.
 
 "mir-kiosk" provides the graphical environment needed for running a graphical snap.
 
-Next, you will need to enable the experimental “layouts” feature as we did in the Wayland guide:
-
-
-```bash
-sudo snap set core experimental.layouts=true
-```
-
-
 
 ## Snapping to use mir-kiosk
 

--- a/tutorials/iot/ubuntu-kiosk/x11-kiosk.md
+++ b/tutorials/iot/ubuntu-kiosk/x11-kiosk.md
@@ -213,7 +213,7 @@ This is the basic setup that we'll have in our snap. It seems like a lot of work
 
 duration: 5:00
 
-For our first pass we will snap glxgears and run it in devmode (i.e. unconfined) on our Ubuntu desktop. We use [xwayland-kiosk-helpers](https://github.com/MirServer/xwayland-kiosk-helper/) to make life easier, as it runs the above commands for us.
+For our first pass we will snap glxgears and run it in devmode (i.e. unconfined) on our Ubuntu desktop. We will include an [xwayland-kiosk-helper](https://github.com/MirServer/xwayland-kiosk-helper/) part that make life easier, it contains a script that runs the above commands for us.
 
 This guide assumes you are familiar with creating snaps. If not, please read [here](https://docs.snapcraft.io/build-snaps/) first. 
 
@@ -249,9 +249,14 @@ apps:
 parts:
   glxgears:
     plugin: nil
-    after: [ xwayland-kiosk-helper ]
     stage-packages:
       - mesa-utils
+
+  xwayland-kiosk-helper:
+    plugin: cmake
+    source: https://github.com/MirServer/xwayland-kiosk-helper.git
+    build-packages: [ build-essential ]
+    stage-packages: [ xwayland, i3, libegl1-mesa, libgl1-mesa-glx ]
 ```
 
 
@@ -261,7 +266,7 @@ Create the snap by returning to the "glxgears" directory and running
 
 
 ```bash
-snapcraft cleanbuild
+snapcraft
 ```
 
 
@@ -338,9 +343,14 @@ apps:
 parts:
   glxgears:
     plugin: nil
-    after: [ xwayland-kiosk-helper ]
     stage-packages:
       - mesa-utils
+
+  xwayland-kiosk-helper:
+    plugin: cmake
+    source: https://github.com/MirServer/xwayland-kiosk-helper.git
+    build-packages: [ build-essential ]
+    stage-packages: [ xwayland, i3, libegl1-mesa, libgl1-mesa-glx ]
 ```
 
 
@@ -348,7 +358,7 @@ Check this builds locally before proceeding:
 
 
 ```bash
-snapcraft cleanbuild
+snapcraft
 ```
 
 
@@ -449,9 +459,14 @@ apps:
 parts:
   glxgears:
     plugin: nil
-    after: [ xwayland-kiosk-helper ]
     stage-packages:
       - mesa-utils
+
+  xwayland-kiosk-helper:
+    plugin: cmake
+    source: https://github.com/MirServer/xwayland-kiosk-helper.git
+    build-packages: [ build-essential ]
+    stage-packages: [ xwayland, i3, libegl1-mesa, libgl1-mesa-glx ]
 
 plugs:
   x11-plug: # because cannot have identical plug/slot name in same yaml.

--- a/tutorials/iot/ubuntu-kiosk/x11-kiosk.md
+++ b/tutorials/iot/ubuntu-kiosk/x11-kiosk.md
@@ -293,7 +293,7 @@ Open another terminal and ssh login to your device and from this login install t
 
 
 ```bash
-sudo snap install mir-kiosk
+snap install mir-kiosk
 ```
 
 


### PR DESCRIPTION
## Done

Update the Mir-kiosk IoT guides to reflect:
- adopt core18 by default
- use newer snapcraft/snapd features

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8016/](http://0.0.0.0:8016/)
- Follow the tutorials and ensure the steps are correct

