### PR TITLE
Fix link to charmed kubernetes

### DIFF
--- a/tutorials/containers/install-a-local-kubernetes-with-microk8s/install-a-local-kubernetes-with-microk8s.md
+++ b/tutorials/containers/install-a-local-kubernetes-with-microk8s/install-a-local-kubernetes-with-microk8s.md
@@ -297,6 +297,6 @@ microk8s.stop
 [nodeport]: https://kubernetes.io/docs/concepts/services-networking/service/#nodeport
 [snap-channels]: https://docs.snapcraft.io/channels/551
 [ubuntu-kubernetes]: https://ubuntu.com/kubernetes
-[charmed-kubernetes]: https://tutorials.ubuntu.com/tutorial/get-started-canonical-kubernetes#0
+[charmed-kubernetes]: https://tutorials.ubuntu.com/tutorial/get-started-charmed-kubernetes#0
 [contact]: https://ubuntu.com/kubernetes#get-in-touch
 [snapd-documentation]: https://snapcraft.io/docs/installing-snapd


### PR DESCRIPTION
## Done

- Updated broken link

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8016/](http://0.0.0.0:8016/)
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes: https://github.com/ubuntu/microk8s/issues/670

