### PR TITLE
Change OSM client version to '--beta'.

### DIFF
--- a/tutorials/telco/charmed-osm-get-started/charmed-osm-get-started.md
+++ b/tutorials/telco/charmed-osm-get-started/charmed-osm-get-started.md
@@ -65,7 +65,7 @@ Install Juju and OSM client from the snap store:
 ```bash
 $ sudo snap install juju --classic
 juju 2.6.10 from Canonical✓ installed
-$ sudo snap install osmclient --edge
+$ sudo snap install osmclient --beta
 osmclient (edge) 0+git.44be24a from Adam Israel (adam) installed
 ```
 


### PR DESCRIPTION
This patchset updates OSM client installation instructions to use
'--beta' version instead of '--edge'.

## Done

[List of work items including drive-bys]

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8016/](http://0.0.0.0:8016/)
- [List additional steps to QA the new features or prove the bug has been resolved]


## Issue / Card

[List of links to Github issues/bugs and cards if needed - e.g. `Fixes #1`]

## Screenshots

[if relevant, include a screenshot]
